### PR TITLE
Add a validate workflow for each template

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,49 @@
+name: Validate
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+env:
+  NODE_VERSION: 20
+  PNPM_VERSION: 9
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        template:
+          - frontend-vanilla
+          - frontend-vue
+          - no-frontend
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install
+        working-directory: templates/${{ matrix.template }}
+
+      - name: Build
+        run: pnpm build
+        working-directory: templates/${{ matrix.template }}
+
+      - name: Typecheck
+        run: pnpm typecheck
+        working-directory: templates/${{ matrix.template }}


### PR DESCRIPTION
Fixes #3

Add a validate workflow to ensure templates are not broken.

* Create a new workflow file `.github/workflows/validate.yml`.
* Add `on` section to trigger workflow on push to `main` and on new PRs.
* Add `env` section to set `NODE_VERSION` and `PNPM_VERSION`.
* Add a job matrix to run `pnpm install`, `pnpm build`, and `pnpm typecheck` for each template in parallel.
* Add steps to checkout project, setup Node.js, setup pnpm, install dependencies, build, and typecheck for each template.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/caido-community/create-plugin/issues/3?shareId=ecec890a-941e-4c9b-ba61-2873fcb5a01c).