### PR TITLE
add: cursor rules

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -14,6 +14,8 @@ export const scaffold = async (config: ScaffoldConfig) => {
     errorOnExist: true,
   });
 
+  await copySharedCursorRules(destinationPath);
+
   console.log(`[*] Template created in ${destinationPath}`);
   console.log(`[*] Run the following commands to get started:`);
   console.log(`[*] - cd ${destinationPath}`);
@@ -42,4 +44,26 @@ const getDestinationPath = (config: ScaffoldConfig) => {
     "-",
   );
   return path.join(process.cwd(), sanitizedPackageName);
+};
+
+const getSharedCursorRulesPath = () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  return path.join(__dirname, "../", "templates", "shared", "cursor-rules");
+};
+
+const copySharedCursorRules = async (destinationPath: string) => {
+  const sharedRulesSource = getSharedCursorRulesPath();
+  try {
+    await fsPromises.access(sharedRulesSource);
+  } catch {
+    return;
+  }
+
+  const rulesDestination = path.join(destinationPath, ".cursor", "rules");
+  await fsPromises.mkdir(rulesDestination, { recursive: true });
+  await fsPromises.cp(sharedRulesSource, rulesDestination, {
+    recursive: true,
+    errorOnExist: false,
+  });
 };

--- a/templates/shared/cursor-rules/caido-backend.mdc
+++ b/templates/shared/cursor-rules/caido-backend.mdc
@@ -1,0 +1,119 @@
+---
+globs:
+  - "**/packages/backend/**"
+alwaysApply: true
+description: Caido Backend SDK Rules and Patterns
+---
+
+## Caido Backend SDK
+
+### Overview
+
+The Caido Backend SDK is used for server-side logic, data processing, and creating API endpoints that can be called from frontend plugins.
+
+### Entry Point
+
+Backend plugins are initialized via `packages/backend/src/index.ts`:
+
+```typescript
+import { SDK, DefineAPI } from "caido:plugin";
+
+// Define your API functions
+function myCustomFunction(sdk: SDK, param: string) {
+  sdk.console.log(`Called with: ${param}`);
+  return `Processed: ${param}`;
+}
+
+// Export the API type definition
+export type API = DefineAPI<{
+  myCustomFunction: typeof myCustomFunction;
+}>;
+
+// Plugin initialization
+export function init(sdk: SDK<API>) {
+  // Register API endpoints
+  sdk.api.register("myCustomFunction", myCustomFunction);
+}
+```
+
+### SDK Type Definitions
+
+#### Backend SDK with events:
+```typescript
+import { DefineEvents, SDK } from "caido:plugin";
+
+export type BackendEvents = DefineEvents<{
+  "data-updated": { message: string };
+  "status-changed": { status: "active" | "inactive" };
+}>;
+
+export type CaidoBackendSDK = SDK<never, BackendEvents>;
+```
+
+### Best Practices
+
+When building API endpoints in the backend and calling them from the frontend, use Result types to handle errors gracefully without throwing exceptions:
+
+```typescript
+// Define the Result type
+export type Result<T> =
+  | { kind: "Error"; error: string }
+  | { kind: "Ok"; value: T };
+
+// Backend API function returning Result
+function processData(sdk: SDK, input: string): Result<ProcessedData> {
+  try {
+    // Your processing logic here
+    const processed = doSomeProcessing(input);
+    return { kind: "Ok", value: processed };
+  } catch (error) {
+    return { kind: "Error", error: error.message };
+  }
+}
+
+// Frontend usage - no try/catch needed
+const handleProcess = async () => {
+  const result = await sdk.backend.processData(inputValue);
+
+  if (result.kind === "Error") {
+    sdk.window.showToast(result.error, { variant: "error" });
+    return;
+  }
+
+  // Handle successful result
+  const data = result.value;
+  sdk.window.showToast("Processing completed!", { variant: "success" });
+};
+```
+
+
+#### Registering Multiple API Endpoints
+
+```typescript
+// Define multiple API functions
+function getData(sdk: SDK, id: string): Result<Data> {
+  // Implementation
+}
+
+function saveData(sdk: SDK, data: Data): Result<void> {
+  // Implementation
+}
+
+function deleteData(sdk: SDK, id: string): Result<boolean> {
+  // Implementation
+}
+
+// Export Caido Backend API
+export type API = DefineAPI<{
+  getData: typeof getData;
+  saveData: typeof saveData;
+  deleteData: typeof deleteData;
+}>;
+
+// Register all endpoints
+export function init(sdk: SDK<API>) {
+  sdk.api.register("getData", getData);
+  sdk.api.register("saveData", saveData);
+  sdk.api.register("deleteData", deleteData);
+}
+```

--- a/templates/shared/cursor-rules/caido-frontend.mdc
+++ b/templates/shared/cursor-rules/caido-frontend.mdc
@@ -1,0 +1,159 @@
+---
+globs:
+  - "**/packages/frontend/**"
+alwaysApply: true
+description: Caido Frontend SDK Rules and Patterns
+---
+
+## Caido Frontend SDK
+
+### Overview
+
+The Caido Frontend SDK is used for creating UI components, pages, and handling user interactions in Caido plugins.
+
+### Entry Point
+
+Frontend plugins are initialized via `packages/frontend/src/index.ts`:
+
+```typescript
+import { Caido } from "@caido/sdk-frontend";
+import { API, BackendEvents } from "backend";
+
+// Define SDK type with backend API
+export type FrontendSDK = Caido<API, BackendEvents>;
+
+// Plugin initialization
+export const init = (sdk: FrontendSDK) => {
+  // Create pages and UI
+  createPage(sdk);
+
+  // Register sidebar items
+  sdk.sidebar.registerItem("My Plugin", "/my-plugin-page", {
+    icon: "fas fa-rocket"
+  });
+
+  // Register commands
+  sdk.commands.register("my-command", {
+    name: "My Custom Command",
+    run: () => sdk.backend.myCustomFunction("Hello"),
+  });
+};
+```
+
+### SDK Type Definitions
+
+#### For plugins WITHOUT backend, this is fine:
+```typescript
+export type FrontendSDK = Caido<Record<string, never>, Record<string, never>>;
+```
+
+#### For plugins WITH backend:
+```typescript
+import { Caido } from "@caido/sdk-frontend";
+import { API, BackendEvents } from "backend";
+
+export type FrontendSDK = Caido<API, BackendEvents>;
+```
+
+### Command Pattern
+
+Commands provide a unified way to register actions that can be triggered from:
+- Command palette (Ctrl/Cmd+Shift+P)
+- Context menus (right-click)
+- UI buttons
+- Keyboard shortcuts
+
+Commands is a frontend-only concept.
+
+```typescript
+// Define command IDs as constants
+const Commands = {
+  processData: "my-plugin.process-data",
+  exportResults: "my-plugin.export-results",
+} as const;
+
+// Register commands
+sdk.commands.register(Commands.processData, {
+  name: "Process Data",
+  run: async () => {
+    const result = await sdk.backend.processData();
+    sdk.window.showToast(`Processed ${result.count} items`, {
+      variant: "success"
+    });
+  },
+  group: "My Plugin",
+});
+
+// Add to command palette
+sdk.commandPalette.register(Commands.processData);
+
+// Add to context menus
+sdk.menu.registerItem({
+  type: "Request",
+  commandId: Commands.processData,
+  leadingIcon: "fas fa-cog",
+});
+```
+
+### Working with Requests and Responses
+
+#### Creating and Sending Requests
+
+```typescript
+import { RequestSpec } from "caido:utils";
+import { type Request, type Response } from "caido:utils";
+
+// Create a new request
+const spec = new RequestSpec("https://api.example.com/data");
+spec.setMethod("POST");
+spec.setHeader("Content-Type", "application/json");
+spec.setBody(JSON.stringify({ key: "value" }));
+
+// Send the request
+const result = await sdk.requests.send(spec);
+if (result.response) {
+  const statusCode = result.response.getCode();
+  const responseBody = result.response.getBody()?.toText();
+}
+```
+
+#### Working with Request/Response Editors
+
+```typescript
+// Create editors for viewing/editing HTTP data
+const reqEditor = sdk.ui.httpRequestEditor();
+const respEditor = sdk.ui.httpResponseEditor();
+
+// Get DOM elements
+const reqElement = reqEditor.getElement();
+const respElement = respEditor.getElement();
+
+// Style and layout
+reqElement.style.width = "50%";
+respElement.style.width = "50%";
+
+const editorsContainer = document.createElement("div");
+editorsContainer.style.display = "flex";
+editorsContainer.appendChild(reqElement);
+editorsContainer.appendChild(respElement);
+```
+
+### Frontend Error Handling
+
+When calling backend APIs from the frontend, handle Result types gracefully:
+
+```typescript
+// Frontend usage - no try/catch needed
+const handleProcess = async () => {
+  const result = await sdk.backend.processData(inputValue);
+
+  if (result.kind === "Error") {
+    sdk.window.showToast(result.error, { variant: "error" });
+    return;
+  }
+
+  // Handle successful result
+  const data = result.value;
+  sdk.window.showToast("Processing completed!", { variant: "success" });
+};
+```

--- a/templates/shared/cursor-rules/caido.mdc
+++ b/templates/shared/cursor-rules/caido.mdc
@@ -1,0 +1,97 @@
+---
+globs:
+alwaysApply: true
+description: Caido HTTP Proxy Overview
+---
+
+## What is Caido
+
+Caido is a lightweight web application security auditing toolkit designed to help security professionals audit web applications with efficiency and ease
+
+Key features include:
+  - HTTP proxy for intercepting and viewing requests in real-time
+  - Replay functionality for resending and modifying requests to test endpoints
+  - Automate feature for testing requests against wordlists
+  - Match & Replace for automatically modifying requests with regex rules
+  - HTTPQL query language for filtering through HTTP traffic
+  - Workflow system for creating custom encoders/decoders and plugins
+  - Project management for organizing different security assessments
+
+## Environment
+
+We are running in a plugin environment where we can interact with Caido through the Caido Backend or Frontend SDK.
+
+### Plugin Structure
+
+- `packages/backend` → Backend plugin code - handles server-side logic, data processing, and API endpoints
+- `packages/frontend` → Frontend plugin code - handles UI components, user interactions, and calls to backend
+
+### Plugin Development
+
+Plugins consist of:
+- A `caido.config.ts` configuration file
+- Frontend plugin (optional) - provides UI using Caido Frontend SDK
+- Backend plugin (optional) - provides server-side functionality using Caido Backend SDK
+
+These are packaged together as a single plugin package that can be installed in Caido.
+
+### Key Development Concepts
+
+- Frontend plugins create pages, UI components, and handle user interactions
+- Backend plugins register API endpoints that can be called from frontend
+- Communication between frontend and backend happens through registered API calls
+
+### Caido Findings SDK
+
+Findings allow you to create alerts when Caido detects notable characteristics in requests/responses based on conditional statements. When triggered, they generate alerts to draw attention to interesting traffic.
+
+Example - Create a finding for successful responses:
+```typescript
+await sdk.findings.create({
+  title: `Success Response ${response.getCode()}`,
+  description: `Request ID: ${request.getId()}\nResponse Code: ${response.getCode()}`,
+  reporter: "Response Logger Plugin",
+  request: request,
+  dedupeKey: `${request.getPath()}-${response.getCode()}` // Prevents duplicates
+});
+```
+
+### Important Caido SDK Types
+
+```typescript
+export type Request = {
+  getId(): ID;
+  getHost(): string;
+  getPort(): number;
+  getTls(): boolean;
+  getMethod(): string;
+  getPath(): string;
+  getQuery(): string;
+  getUrl(): string;
+  getHeaders(): Record<string, Array<string>>;
+  getHeader(name: string): Array<string> | undefined;
+  getBody(): Body | undefined;
+  getRaw(): RequestRaw;
+  getCreatedAt(): Date;
+  toSpec(): RequestSpec;
+  toSpecRaw(): RequestSpecRaw;
+};
+
+export type Response = {
+  getId(): ID;
+  getCode(): number;
+  getHeaders(): Record<string, Array<string>>;
+  getHeader(name: string): Array<string> | undefined;
+  getBody(): Body | undefined;
+  getRaw(): ResponseRaw;
+  getRoundtripTime(): number;
+  getCreatedAt(): Date;
+};
+```
+
+For Body and Raw you can use methods like `getBody()?.toText()` to extract text content.
+
+These types can be imported by:
+```
+import { type Request, type Response } from "caido:utils";
+```

--- a/templates/shared/cursor-rules/linter.mdc
+++ b/templates/shared/cursor-rules/linter.mdc
@@ -1,0 +1,25 @@
+---
+globs:
+alwaysApply: true
+description: Linter Guidelines
+---
+
+# Linter
+
+We have a built-in ESLint linter configured at the root folder. After making any significant change, always run the linter with `pnpm lint` and fix all potential issues.
+
+## Most common mistakes that lead to linter errors
+
+### Lint Rule: Unexpected nullable string value in conditional. Please handle nullish or empty cases explicitly
+
+To prevent this, when comparing strings, instead of writing:
+
+```
+if (!str) {}
+```
+
+do this:
+
+```
+if (str !== undefined) {}
+```

--- a/templates/shared/cursor-rules/style.mdc
+++ b/templates/shared/cursor-rules/style.mdc
@@ -1,0 +1,51 @@
+---
+globs: **/**.vue
+alwaysApply: false
+---
+## UI Style Guidelines
+
+### PrimeVue
+
+- Prefer to use PrimeVue compontents where possible
+- A custom PrimeVue theme is configured with dark mode as default, handling most color-related styles for us.
+
+### General Theme
+
+- Dark Mode is default — all UI elements follow a dark, low-contrast background with light text for high readability.
+- For text / background colors, prefer to use `...-surface-...` f.e. `border-surface-700`.
+- Caido uses `bg-surface-800` as the main app background, `bg-surface-700` is the background used for `Card` component.
+- Follow minimalistic color palette. AVOID using too much colors where possible.
+
+### Layout & Components
+
+- Often use PrimeVue `Splitter` and `SplitterPanel` for vertical or horizontal layout.
+- Prefer to use `Card` PrimeVue components a lot, if needed add `h-full` to them via `pt` params.
+
+Example:
+
+```
+<Card
+  class="h-full"
+  :pt="{
+    body: { class: 'h-full p-0' },
+    content: { class: 'h-full flex flex-col' },
+  }"
+>
+```
+
+### Enviroment
+
+- Keep in mind that we are building a plugin that's inside a Caido web app, we can modify frontend by adding sidebar pages using Caido Frontend SDK.
+- Our plugin content is rendered within a dedicated window/panel that Caido provides for our sidebar page.
+- The plugin UI should integrate seamlessly with Caido's existing interface and theming.
+
+### Data Representation
+
+- Prefer `DataTable` component for displaying structured data:
+  * Caido often uses `stripedRows`, use it where possible
+  * Actions column at the end (e.g. “Install” buttons).
+- Empty states use friendly, minimal messages with icons.
+
+### Icons
+
+- Always use `fas fa-[...]` for icons. We don't support any other icon libraries.

--- a/templates/shared/cursor-rules/typescript.mdc
+++ b/templates/shared/cursor-rules/typescript.mdc
@@ -1,0 +1,16 @@
+---
+globs:
+alwaysApply: true
+description: TypeScript Guidelines
+---
+# TypeScript Guidelines
+
+- Use TypeScript for all files.
+- NEVER use `any` type.
+- Use `undefined` over `null`.
+- Try to keep things in one function unless composable or reusable.
+- Prefer single word variable names where possible.
+- DO NOT do unnecessary destructuring of variables.
+- AVOID `else` statements where possible.
+- AVOID `try` / `catch` where possible.
+- AVOID using interfaces where possible.


### PR DESCRIPTION
This PR adds Cursor rules at `.cursor/rules/[...]` to both templates.
Cursor Rules are placed in `templates/shared/cursor-rules` and then `scaffold.ts` copies them to the template.